### PR TITLE
feat: ログイン画面の改修 (closes #2)

### DIFF
--- a/src/frontend/src/components/Login.vue
+++ b/src/frontend/src/components/Login.vue
@@ -42,6 +42,43 @@
           <div class="mt-12 text-center">
             {{ msg }}
           </div>
+
+          <div data-testid="bear-illustration" class="mt-6 text-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 120 120"
+              width="120"
+              height="120"
+              aria-label="くまさんのイラスト"
+              role="img"
+            >
+              <!-- 耳 -->
+              <circle cx="38" cy="30" r="14" fill="#8B6914" />
+              <circle cx="82" cy="30" r="14" fill="#8B6914" />
+              <!-- 耳の内側 -->
+              <circle cx="38" cy="30" r="9" fill="#E8A87C" />
+              <circle cx="82" cy="30" r="9" fill="#E8A87C" />
+              <!-- 頭 -->
+              <circle cx="60" cy="55" r="30" fill="#A0792A" />
+              <!-- 体 -->
+              <ellipse cx="60" cy="96" rx="24" ry="18" fill="#A0792A" />
+              <!-- 顔の白い部分 -->
+              <ellipse cx="60" cy="62" rx="16" ry="13" fill="#D4A574" />
+              <!-- 目 -->
+              <circle cx="51" cy="50" r="4" fill="#2C1810" />
+              <circle cx="69" cy="50" r="4" fill="#2C1810" />
+              <!-- 目のハイライト -->
+              <circle cx="52.5" cy="48.5" r="1.5" fill="white" />
+              <circle cx="70.5" cy="48.5" r="1.5" fill="white" />
+              <!-- 鼻 -->
+              <ellipse cx="60" cy="59" rx="5" ry="4" fill="#2C1810" />
+              <!-- 口 -->
+              <path d="M54 65 Q60 71 66 65" stroke="#2C1810" stroke-width="2" fill="none" stroke-linecap="round" />
+              <!-- ほっぺ -->
+              <circle cx="43" cy="60" r="6" fill="#FF9E9E" opacity="0.65" />
+              <circle cx="77" cy="60" r="6" fill="#FF9E9E" opacity="0.65" />
+            </svg>
+          </div>
         </v-form>
       </v-card-text>
     </v-card>

--- a/src/frontend/tests/unit/Login.spec.js
+++ b/src/frontend/tests/unit/Login.spec.js
@@ -1,0 +1,41 @@
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import { createRouter, createWebHistory } from 'vue-router'
+import Login from '@/components/Login.vue'
+
+const store = createStore({
+  state: { isAuthenticated: false },
+  actions: {
+    login: jest.fn().mockResolvedValue(''),
+  },
+})
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [{ path: '/', component: { template: '<div/>' } }],
+})
+
+describe('Login.vue', () => {
+  it('ログインフォームが表示される', () => {
+    const wrapper = mount(Login, {
+      global: { plugins: [store, router] },
+    })
+    expect(wrapper.find('form').exists()).toBe(true)
+  })
+
+  it('くまさんのイラストがログイン画面下部に表示される', () => {
+    const wrapper = mount(Login, {
+      global: { plugins: [store, router] },
+    })
+    const bear = wrapper.find('[data-testid="bear-illustration"]')
+    expect(bear.exists()).toBe(true)
+  })
+
+  it('くまさんのイラストはSVG要素である', () => {
+    const wrapper = mount(Login, {
+      global: { plugins: [store, router] },
+    })
+    const svg = wrapper.find('[data-testid="bear-illustration"] svg')
+    expect(svg.exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #2

## 変更内容

- src/frontend/src/components/Login.vue — ログインフォーム下部にかわいいくまさんの SVG イラストを追加
  - data-testid="bear-illustration" でテスト可能
  - ria-label / ole="img" でアクセシビリティ対応
  - inline SVG のため外部依存なし
- src/frontend/tests/unit/Login.spec.js — くまさんイラスト表示に関するユニットテストを追加
  - フォーム表示確認テスト
  - イラスト要素存在確認テスト
  - SVG 要素確認テスト

## テスト

- Login.spec.js に 3 件のテストケースを追加
  1. ログインフォームが表示される
  2. くまさんのイラストがログイン画面下部に表示される
  3. くまさんのイラストは SVG 要素である

---
> ⚠️ AI により自動生成された PR です。必ずレビューしてからマージしてください。