### PR TITLE
bug fix for 404 notfound when requested to /api/config

### DIFF
--- a/src/frontend/src/app/layout.tsx
+++ b/src/frontend/src/app/layout.tsx
@@ -6,10 +6,17 @@ export const metadata = {
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  // Server Component: process.env を直接読んで backendUrl を構築する。
+  // fetch('/api/config') を廃止し、本番 Ingress の /api/* ルーティング競合を回避する。
+  const protocol  = process.env.BACKEND_PROTOCOL ?? 'http'
+  const server    = process.env.BACKEND_SERVER   ?? 'localhost'
+  const port      = process.env.BACKEND_PORT     ?? '3000'
+  const backendUrl = `${protocol}://${server}:${port}`
+
   return (
     <html lang="ja">
       <body>
-        <Providers>{children}</Providers>
+        <Providers backendUrl={backendUrl}>{children}</Providers>
       </body>
     </html>
   )

--- a/src/frontend/src/app/providers.tsx
+++ b/src/frontend/src/app/providers.tsx
@@ -11,12 +11,17 @@ const theme = createTheme({
   },
 })
 
-export function Providers({ children }: { children: ReactNode }) {
-  const configInit = useConfigStore((s) => s.init)
+interface ProvidersProps {
+  children: ReactNode
+  backendUrl: string
+}
+
+export function Providers({ children, backendUrl }: ProvidersProps) {
+  const setBackendUrl = useConfigStore((s) => s.setBackendUrl)
 
   useEffect(() => {
-    configInit()
-  }, [configInit])
+    setBackendUrl(backendUrl)
+  }, [backendUrl, setBackendUrl])
 
   return (
     <AppRouterCacheProvider>

--- a/src/frontend/src/lib/store/configStore.ts
+++ b/src/frontend/src/lib/store/configStore.ts
@@ -3,17 +3,11 @@ import { create } from 'zustand'
 interface ConfigState {
   backendUrl: string | null
   initialized: boolean
-  init: () => Promise<void>
+  setBackendUrl: (url: string) => void
 }
 
-export const useConfigStore = create<ConfigState>((set, get) => ({
+export const useConfigStore = create<ConfigState>((set) => ({
   backendUrl: null,
   initialized: false,
-
-  init: async () => {
-    if (get().initialized) return
-    const res = await fetch('/api/config')
-    const data = await res.json()
-    set({ backendUrl: data.backendUrl, initialized: true })
-  },
+  setBackendUrl: (url: string) => set({ backendUrl: url, initialized: true }),
 }))


### PR DESCRIPTION
変更前: ブラウザ → GET /api/config → LB が /api/* をバックエンドへ → 404

変更後: layout.tsx (Server Component, Next.js 内で実行)
    → process.env.BACKEND_* を直接読む
    → backendUrl を props で Providers に渡す
    → ブラウザは /api/config に一切リクエストしない
変更した3ファイル:

ファイル	変更内容 configStore.ts	init() 削除 → setBackendUrl(url) に置換 providers.tsx	backendUrl props を受け取り setBackendUrl() を呼ぶ layout.tsx	Server Component として process.env を読んで backendUrl を計算し Providers に渡す